### PR TITLE
fix: Resolve checkupdates errors when run in parrallel / errors shown on applet when on multiple screens

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,6 @@
+unstable_features = true
+# Auto format comment width for this project. Note that this is an unstable feature.
+wrap_comments = true
+# Auto format doc comments, also unstable.
+format_code_in_doc_comments = true
+edition = "2021"

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,5 @@
+imports_granularity = "Module"
+group_imports = "One"
 unstable_features = true
 # Auto format comment width for this project. Note that this is an unstable feature.
 wrap_comments = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,6 @@ dependencies = [
  "arch-updates-rs",
  "chrono",
  "directories",
- "fd-lock",
  "futures",
  "i18n-embed",
  "i18n-embed-fl",
@@ -1005,6 +1004,7 @@ dependencies = [
  "ron 0.8.1",
  "rss",
  "rust-embed",
+ "rustix 1.0.5",
  "serde",
  "tempfile",
  "tokio",
@@ -1661,17 +1661,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix 1.0.5",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "fdeflate"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ dependencies = [
  "arch-updates-rs",
  "chrono",
  "directories",
+ "fd-lock",
  "futures",
  "i18n-embed",
  "i18n-embed-fl",
@@ -1660,6 +1661,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.0.5",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "fdeflate"
@@ -3306,6 +3318,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4869,6 +4887,19 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 

--- a/arch-updates-rs/src/get_updates.rs
+++ b/arch-updates-rs/src/get_updates.rs
@@ -77,6 +77,8 @@ async fn get_ignored_packages() -> Result<Vec<String>> {
 }
 
 /// Wrapper around external 'checkupdates' tool.
+/// # Note
+/// This will fail if somebody else is running 'checkupdates' in sync mode at the same time (it cannot run in parrellel).
 pub async fn checkupdates(mode: CheckupdatesMode) -> Result<Vec<ParsedUpdate>> {
     let (args, _lock) = match mode {
         CheckupdatesMode::NoSync => (["--nosync", "--nocolor"].as_slice(), None),

--- a/arch-updates-rs/src/get_updates.rs
+++ b/arch-updates-rs/src/get_updates.rs
@@ -78,7 +78,8 @@ async fn get_ignored_packages() -> Result<Vec<String>> {
 
 /// Wrapper around external 'checkupdates' tool.
 /// # Note
-/// This will fail if somebody else is running 'checkupdates' in sync mode at the same time (it cannot run in parrellel).
+/// This will fail if somebody else is running 'checkupdates' in sync mode at
+/// the same time (it cannot run in parrellel).
 pub async fn checkupdates(mode: CheckupdatesMode) -> Result<Vec<ParsedUpdate>> {
     let (args, _lock) = match mode {
         CheckupdatesMode::NoSync => (["--nosync", "--nocolor"].as_slice(), None),
@@ -277,10 +278,28 @@ pub fn parse_url(source: &str) -> Option<PackageUrl> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::future::try_join;
 
     #[tokio::test]
     async fn test_get_srcinfo() {
         get_aur_srcinfo("hyprlang-git").await.unwrap();
+    }
+    #[tokio::test]
+    async fn test_checkupdates_sync() {
+        checkupdates(CheckupdatesMode::Sync).await.unwrap();
+    }
+    #[tokio::test]
+    async fn test_checkupdates_sync_concurrent() {
+        try_join(
+            checkupdates(CheckupdatesMode::Sync),
+            checkupdates(CheckupdatesMode::Sync),
+        )
+        .await
+        .unwrap();
+    }
+    #[tokio::test]
+    async fn test_checkupdates_nosync() {
+        checkupdates(CheckupdatesMode::NoSync).await.unwrap();
     }
     #[tokio::test]
     async fn test_get_srcinfo_not_in_aur() {

--- a/arch-updates-rs/src/get_updates.rs
+++ b/arch-updates-rs/src/get_updates.rs
@@ -60,7 +60,6 @@ pub fn aur_update_due(package: &AurUpdate) -> bool {
     pkgver_new > pkgver_old || (pkgver_new == pkgver_old && package.pkgrel_new > package.pkgrel_cur)
 }
 
-
 /// pacman conf has a list of packages that should be ignored by pacman. This
 /// command fetches their pkgnames.
 async fn get_ignored_packages() -> Result<Vec<String>> {
@@ -78,31 +77,31 @@ async fn get_ignored_packages() -> Result<Vec<String>> {
 }
 
 /// Wrapper around external 'checkupdates' tool.
-pub async fn checkupdates(mode: CheckupdatesMode)-> Result<Vec<ParsedUpdate>> {
-        let (args, _lock) = match mode {
-            CheckupdatesMode::NoSync =>
-(            ["--nosync", "--nocolor"].as_slice(),
-            None
-)        ,
-    CheckupdatesMode::Sync =>
-(            ["--nocolour"].as_slice(),
+pub async fn checkupdates(mode: CheckupdatesMode) -> Result<Vec<ParsedUpdate>> {
+    let (args, _lock) = match mode {
+        CheckupdatesMode::NoSync => (["--nosync", "--nocolor"].as_slice(), None),
+        CheckupdatesMode::Sync => (
+            ["--nocolour"].as_slice(),
             // When using the online version of 'checkupdates', it will fail if run concurrently.
             // So we use this sempahore to represent if it is running.
-            Some(CHECKUPDATES_DB_LOCK.acquire().await.expect("CHECKUPDATES_DB_LOCK cannot be closed, it is static"))
-)        };
-        let output = Command::new("checkupdates")
-            .args(args)
-            .output()
-            .await?;
-        // Guard against stderr from checkupdates.
-        let stderr = str::from_utf8(output.stderr.as_slice())?;
-        if !stderr.is_empty() {
-            return Err(Error::CheckUpdatesReturnedError(stderr.to_owned()));
-        };
-        str::from_utf8(output.stdout.as_slice())?
-            .lines()
-            .map(parse_update)
-            .collect::<Result<Vec<_>>>()
+            Some(
+                CHECKUPDATES_DB_LOCK
+                    .acquire()
+                    .await
+                    .expect("CHECKUPDATES_DB_LOCK cannot be closed, it is static"),
+            ),
+        ),
+    };
+    let output = Command::new("checkupdates").args(args).output().await?;
+    // Guard against stderr from checkupdates.
+    let stderr = str::from_utf8(output.stderr.as_slice())?;
+    if !stderr.is_empty() {
+        return Err(Error::CheckUpdatesReturnedError(stderr.to_owned()));
+    };
+    str::from_utf8(output.stdout.as_slice())?
+        .lines()
+        .map(parse_update)
+        .collect::<Result<Vec<_>>>()
 }
 
 /// Get a list of all aur packages on the system.

--- a/arch-updates-rs/src/get_updates.rs
+++ b/arch-updates-rs/src/get_updates.rs
@@ -79,7 +79,7 @@ async fn get_ignored_packages() -> Result<Vec<String>> {
 /// Wrapper around external 'checkupdates' tool.
 /// # Note
 /// This will fail if somebody else is running 'checkupdates' in sync mode at
-/// the same time (it cannot run in parrellel).
+/// the same time (it cannot run in parallel).
 pub async fn checkupdates(mode: CheckupdatesMode) -> Result<Vec<ParsedUpdate>> {
     let (args, _lock) = match mode {
         CheckupdatesMode::NoSync => (["--nosync", "--nocolor"].as_slice(), None),

--- a/arch-updates-rs/src/get_updates.rs
+++ b/arch-updates-rs/src/get_updates.rs
@@ -4,7 +4,8 @@ use core::str;
 use raur::Raur;
 use srcinfo::Srcinfo;
 use std::str::FromStr;
-use tokio::{process::Command, sync::Semaphore};
+use tokio::process::Command;
+use tokio::sync::Semaphore;
 use version_compare::Version;
 
 /// The online version of 'checkupdates', cannot run concurrently.

--- a/arch-updates-rs/src/get_updates.rs
+++ b/arch-updates-rs/src/get_updates.rs
@@ -81,7 +81,7 @@ pub async fn checkupdates(mode: CheckupdatesMode) -> Result<Vec<ParsedUpdate>> {
     let (args, _lock) = match mode {
         CheckupdatesMode::NoSync => (["--nosync", "--nocolor"].as_slice(), None),
         CheckupdatesMode::Sync => (
-            ["--nocolour"].as_slice(),
+            ["--nocolor"].as_slice(),
             // When using the online version of 'checkupdates', it will fail if run concurrently.
             // So we use this sempahore to represent if it is running.
             Some(

--- a/arch-updates-rs/src/lib.rs
+++ b/arch-updates-rs/src/lib.rs
@@ -42,7 +42,9 @@
 use core::str;
 use futures::{future::try_join, stream::FuturesOrdered, StreamExt, TryStreamExt};
 use get_updates::{
-    aur_update_due, checkupdates, devel_update_due, get_aur_packages, get_aur_srcinfo, get_devel_packages, get_head_identifier, parse_update, parse_url, parse_ver_and_rel, CheckupdatesMode, PackageUrl
+    aur_update_due, checkupdates, devel_update_due, get_aur_packages, get_aur_srcinfo,
+    get_devel_packages, get_head_identifier, parse_update, parse_url, parse_ver_and_rel,
+    CheckupdatesMode, PackageUrl,
 };
 use raur::Raur;
 use source_repo::{add_sources_to_updates, get_sources_list, SourcesList};
@@ -152,7 +154,8 @@ pub struct DevelUpdatesCache(Vec<DevelUpdate>);
 /// assert!(updates.is_empty());
 /// # };
 pub async fn check_pacman_updates_online() -> Result<(Vec<PacmanUpdate>, PacmanUpdatesCache)> {
-    let (parsed_updates, source_info) = try_join(checkupdates(CheckupdatesMode::Sync), get_sources_list()).await?;
+    let (parsed_updates, source_info) =
+        try_join(checkupdates(CheckupdatesMode::Sync), get_sources_list()).await?;
     let updates = add_sources_to_updates(parsed_updates, &source_info);
     Ok((updates, PacmanUpdatesCache(source_info)))
 }

--- a/arch-updates-rs/src/lib.rs
+++ b/arch-updates-rs/src/lib.rs
@@ -43,8 +43,8 @@ use core::str;
 use futures::{future::try_join, stream::FuturesOrdered, StreamExt, TryStreamExt};
 use get_updates::{
     aur_update_due, checkupdates, devel_update_due, get_aur_packages, get_aur_srcinfo,
-    get_devel_packages, get_head_identifier, parse_url, parse_ver_and_rel,
-    CheckupdatesMode, PackageUrl,
+    get_devel_packages, get_head_identifier, parse_url, parse_ver_and_rel, CheckupdatesMode,
+    PackageUrl,
 };
 use raur::Raur;
 use source_repo::{add_sources_to_updates, get_sources_list, SourcesList};
@@ -145,8 +145,8 @@ pub struct DevelUpdatesCache(Vec<DevelUpdate>);
 ///  - Cache that can be stored in memory to make next query more efficient.
 ///
 /// # Note
-/// This will fail with an error if somebody else is running 'checkupdates' in sync
-/// mode at the same time.
+/// This will fail with an error if somebody else is running 'checkupdates' in
+/// sync mode at the same time.
 /// # Usage
 /// ```no_run
 /// # use arch_updates_rs::*;

--- a/arch-updates-rs/src/lib.rs
+++ b/arch-updates-rs/src/lib.rs
@@ -43,7 +43,7 @@ use core::str;
 use futures::{future::try_join, stream::FuturesOrdered, StreamExt, TryStreamExt};
 use get_updates::{
     aur_update_due, checkupdates, devel_update_due, get_aur_packages, get_aur_srcinfo,
-    get_devel_packages, get_head_identifier, parse_update, parse_url, parse_ver_and_rel,
+    get_devel_packages, get_head_identifier, parse_url, parse_ver_and_rel,
     CheckupdatesMode, PackageUrl,
 };
 use raur::Raur;

--- a/arch-updates-rs/src/lib.rs
+++ b/arch-updates-rs/src/lib.rs
@@ -144,6 +144,9 @@ pub struct DevelUpdatesCache(Vec<DevelUpdate>);
 ///  - Packages that are not up to date.
 ///  - Cache that can be stored in memory to make next query more efficient.
 ///
+/// # Note
+/// This will fail with an error if somebody else is running 'checkupdates' in sync
+/// mode at the same time.
 /// # Usage
 /// ```no_run
 /// # use arch_updates_rs::*;

--- a/arch-updates-rs/src/lib.rs
+++ b/arch-updates-rs/src/lib.rs
@@ -40,7 +40,9 @@
 //! }
 //! ```
 use core::str;
-use futures::{future::try_join, stream::FuturesOrdered, StreamExt, TryStreamExt};
+use futures::future::try_join;
+use futures::stream::FuturesOrdered;
+use futures::{StreamExt, TryStreamExt};
 use get_updates::{
     aur_update_due, checkupdates, devel_update_due, get_aur_packages, get_aur_srcinfo,
     get_devel_packages, get_head_identifier, parse_url, parse_ver_and_rel, CheckupdatesMode,
@@ -48,7 +50,8 @@ use get_updates::{
 };
 use raur::Raur;
 use source_repo::{add_sources_to_updates, get_sources_list, SourcesList};
-use std::{io, str::Utf8Error};
+use std::io;
+use std::str::Utf8Error;
 use thiserror::Error;
 
 mod get_updates;

--- a/arch-updates-rs/src/source_repo.rs
+++ b/arch-updates-rs/src/source_repo.rs
@@ -1,9 +1,11 @@
 //! Get the source repo of a package.
 
 use super::Result;
-use crate::{get_updates::ParsedUpdate, Error, PacmanUpdate};
+use crate::get_updates::ParsedUpdate;
+use crate::{Error, PacmanUpdate};
 use core::str;
-use std::{collections::HashMap, fmt::Display};
+use std::collections::HashMap;
+use std::fmt::Display;
 
 /// Maps pkgnames to their source repos.
 pub type SourcesList = HashMap<String, SourceRepo>;
@@ -121,11 +123,11 @@ impl Display for SourceRepo {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        get_updates::ParsedUpdate,
-        source_repo::{add_sources_to_updates, get_sources_list, parse_pacman_sl, SourceRepo},
-        Error, PacmanUpdate,
+    use crate::get_updates::ParsedUpdate;
+    use crate::source_repo::{
+        add_sources_to_updates, get_sources_list, parse_pacman_sl, SourceRepo,
     };
+    use crate::{Error, PacmanUpdate};
 
     #[tokio::test]
     async fn test_get_sources_list() {

--- a/cosmic-applet-arch/Cargo.toml
+++ b/cosmic-applet-arch/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = "0.12.12"
 tokio-stream = { version = "0.1.17", features = ["io-util"] }
 directories = "6.0.0"
 anyhow = "1.0.96"
+fd-lock = "4.0.4"
 
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic.git"

--- a/cosmic-applet-arch/Cargo.toml
+++ b/cosmic-applet-arch/Cargo.toml
@@ -20,7 +20,7 @@ reqwest = "0.12.12"
 tokio-stream = { version = "0.1.17", features = ["io-util"] }
 directories = "6.0.0"
 anyhow = "1.0.96"
-fd-lock = "4.0.4"
+rustix = {version = "1.0.5", features = ["fs"]}
 
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic.git"

--- a/cosmic-applet-arch/src/app.rs
+++ b/cosmic-applet-arch/src/app.rs
@@ -11,6 +11,7 @@ use view::Collapsed;
 
 use crate::news::{self, DatedNewsItem};
 
+mod async_file_lock;
 mod subscription;
 mod view;
 

--- a/cosmic-applet-arch/src/app.rs
+++ b/cosmic-applet-arch/src/app.rs
@@ -1,3 +1,4 @@
+use crate::news::{self, DatedNewsItem};
 use chrono::{DateTime, Local};
 use cosmic::app::{Core, Task};
 use cosmic::iced::platform_specific::shell::wayland::commands::popup::{destroy_popup, get_popup};
@@ -8,8 +9,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use subscription::core::Updates;
 use view::Collapsed;
-
-use crate::news::{self, DatedNewsItem};
 
 // See module docs.
 #[cfg(all(unix, not(target_os = "solaris")))]

--- a/cosmic-applet-arch/src/app.rs
+++ b/cosmic-applet-arch/src/app.rs
@@ -11,6 +11,8 @@ use view::Collapsed;
 
 use crate::news::{self, DatedNewsItem};
 
+// See module docs.
+#[cfg(all(unix, not(target_os = "solaris")))]
 mod async_file_lock;
 mod subscription;
 mod view;

--- a/cosmic-applet-arch/src/app/async_file_lock.rs
+++ b/cosmic-applet-arch/src/app/async_file_lock.rs
@@ -21,13 +21,14 @@
 
 use std::path::Path;
 
-/// Acquire an exclusive write lock asynchronously
-/// This can be used to communicate with another process that a lock is applied.
+/// Exclusive advisory lock on a file that remains until this struct is dropped.
+/// # Note
+/// To avoid panicing in Drop, errors unlocking the file are silently ignored.
 #[must_use = "if unused the lock will immediately unlock"]
 pub struct AsyncFileLock(std::fs::File);
 
 impl AsyncFileLock {
-    /// Locks file at `path` until this is dropped.
+    /// Exclusively locks file at `path` until this is dropped.
     /// Creates the file if it does not exist.
     pub async fn new<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
         let file = tokio::fs::OpenOptions::new()

--- a/cosmic-applet-arch/src/app/async_file_lock.rs
+++ b/cosmic-applet-arch/src/app/async_file_lock.rs
@@ -29,7 +29,7 @@ pub struct AsyncFileLock(std::fs::File);
 impl AsyncFileLock {
     /// Locks file at `path` until this is dropped.
     /// Creates the file if it does not exist.
-    pub async fn new<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
+    pub async fn new<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
         let file = tokio::fs::OpenOptions::new()
             .read(true)
             .write(true)

--- a/cosmic-applet-arch/src/app/async_file_lock.rs
+++ b/cosmic-applet-arch/src/app/async_file_lock.rs
@@ -1,0 +1,81 @@
+//! Module to asynchronously provide a file locking mechanism (wrapping
+//! `fd-lock`).
+//! # Note from fd-lock
+//! “advisory locks” are locks which programs must opt-in to adhere to. This
+//! means that they can be used to coordinate file access, but not prevent
+//! access. Use this to coordinate file access between multiple instances of the
+//! same program. But do not use this to prevent actors from accessing or
+//! modifying files.
+
+use fd_lock::RwLock;
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+/// Acquire an exclusive write lock asynchronously
+/// This can be used to communicate with another process that a lock is applied.
+pub struct AsyncFileRwLock(RwLock<File>);
+pub struct AsyncFileRwLockWriteGuard<'lock>(fd_lock::RwLockWriteGuard<'lock, File>);
+
+impl AsyncFileRwLock {
+    pub async fn new<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
+        let file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await?
+            .into_std()
+            .await;
+        let handle = RwLock::new(file);
+        Ok(AsyncFileRwLock(handle))
+    }
+    /// Acquire an exclusive write lock asynchronously
+    /// This doesn't actually do anything, but can be used to communicate with
+    /// another process that a lock is applied. NOTE: This spawns a
+    /// dedicated thread.
+    pub async fn write_lock(&mut self) -> io::Result<AsyncFileRwLockWriteGuard<'_>> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        std::thread::scope(move |s| {
+            s.spawn(move || {
+                tx.send(self.0.write()).unwrap();
+            });
+        });
+        let guard = rx.await.unwrap()?;
+        Ok(AsyncFileRwLockWriteGuard(guard))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::app::async_file_lock::AsyncFileRwLock;
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_async_rw_lock() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let dir = tempdir().unwrap();
+        let mut lock = AsyncFileRwLock::new(dir.path().join("tmp.lock"))
+            .await
+            .unwrap();
+        let guard = lock.write_lock().await.unwrap();
+        let tx_2 = tx.clone();
+        let thread = tokio::spawn(async move {
+            let mut lock = AsyncFileRwLock::new(dir.path().join("tmp.lock"))
+                .await
+                .unwrap();
+            let guard = lock.write_lock().await.unwrap();
+            // This will not run until guard is dropped.
+            tx_2.send(2).unwrap();
+        });
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        tx.send(1).unwrap();
+        drop(guard);
+        tokio::time::timeout(std::time::Duration::from_secs(1), thread)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(rx.iter().collect::<Vec<_>>(), vec![1, 2])
+    }
+}

--- a/cosmic-applet-arch/src/app/subscription.rs
+++ b/cosmic-applet-arch/src/app/subscription.rs
@@ -16,7 +16,6 @@ pub fn subscription(app: &CosmicAppletArch) -> cosmic::iced::Subscription<Messag
     let clear_news_pressed_notifier = app.clear_news_pressed_notifier.clone();
     let news_worker = |tx| news_worker::raw_news_worker(tx, clear_news_pressed_notifier);
     let updates_worker = |tx| updates_worker::raw_updates_worker(tx, refresh_pressed_notifier);
-    // TODO: Determine if INTERVAL is sufficient to prevent too many timeouts.
     let updates_stream =
         cosmic::iced_futures::stream::channel(SUBSCRIPTION_BUF_SIZE, updates_worker);
     let news_stream = cosmic::iced_futures::stream::channel(SUBSCRIPTION_BUF_SIZE, news_worker);

--- a/cosmic-applet-arch/src/app/subscription/core.rs
+++ b/cosmic-applet-arch/src/app/subscription/core.rs
@@ -1,6 +1,5 @@
 use crate::core::proj_dirs;
-use crate::news::NewsCache;
-use crate::news::{DatedNewsItem, WarnedResult};
+use crate::news::{DatedNewsItem, NewsCache, WarnedResult};
 use anyhow::Context;
 use arch_updates_rs::{
     check_pacman_updates_online, AurUpdate, AurUpdatesCache, DevelUpdate, DevelUpdatesCache,

--- a/cosmic-applet-arch/src/app/subscription/messages_to_app.rs
+++ b/cosmic-applet-arch/src/app/subscription/messages_to_app.rs
@@ -2,7 +2,8 @@ use super::core::Updates;
 use super::Message;
 use crate::news::DatedNewsItem;
 use chrono::{DateTime, Local};
-use cosmic::iced::futures::{channel::mpsc, SinkExt};
+use cosmic::iced::futures::channel::mpsc;
+use cosmic::iced::futures::SinkExt;
 
 pub async fn send_update_error(tx: &mut mpsc::Sender<Message>, e: impl std::fmt::Display) {
     tx.send(Message::CheckUpdatesErrorsMsg {

--- a/cosmic-applet-arch/src/app/subscription/mock.rs
+++ b/cosmic-applet-arch/src/app/subscription/mock.rs
@@ -1,9 +1,8 @@
+use super::core::Updates;
 use crate::news::{DatedNewsItem, WarnedResult};
 use arch_updates_rs::{AurUpdate, DevelUpdate, PacmanUpdate, SourceRepo};
 use chrono::FixedOffset;
 use serde::Deserialize;
-
-use super::core::Updates;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct MockDatedNewsItem {

--- a/cosmic-applet-arch/src/app/subscription/news_worker.rs
+++ b/cosmic-applet-arch/src/app/subscription/news_worker.rs
@@ -21,6 +21,7 @@ pub async fn raw_news_worker(
     // If we have no cache, that means we haven't run a succesful online check.
     // Offline checks will be skipped until we can run one.
     let mut residual = None;
+    // TODO: Determine if INTERVAL is sufficient to prevent too many timeouts.
     let mut interval = tokio::time::interval(INTERVAL);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {

--- a/cosmic-applet-arch/src/app/subscription/updates_worker.rs
+++ b/cosmic-applet-arch/src/app/subscription/updates_worker.rs
@@ -17,6 +17,7 @@ pub async fn raw_updates_worker(
     // If we have no cache, that means we haven't run a succesful online check.
     // Offline checks will be skipped until we can run one.
     let mut residual = None;
+    // TODO: Determine if INTERVAL is sufficient to prevent too many timeouts.
     let mut interval = tokio::time::interval(INTERVAL);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {

--- a/cosmic-applet-arch/src/app/view.rs
+++ b/cosmic-applet-arch/src/app/view.rs
@@ -1,18 +1,13 @@
 use crate::app::{CosmicAppletArch, Message, NewsState, UpdatesState};
+use cosmic::app::Core;
+use cosmic::iced::alignment::{Horizontal, Vertical};
+use cosmic::iced::Length;
+use cosmic::theme::Button;
 use cosmic::widget::Id;
-use cosmic::{
-    app::Core,
-    iced::{
-        alignment::{Horizontal, Vertical},
-        Length,
-    },
-    theme::Button,
-    Application, Element,
-};
+use cosmic::{Application, Element};
 use std::borrow::Cow;
 use std::rc::Rc;
 use std::sync::LazyLock;
-
 pub use widgets::*;
 /// What is display when opening the applet menu
 pub mod view_window;

--- a/cosmic-applet-arch/src/app/view/view_window.rs
+++ b/cosmic-applet-arch/src/app/view/view_window.rs
@@ -1,14 +1,9 @@
-use crate::{app::Message, app::UpdatesState, CosmicAppletArch};
-use crate::{
-    app::{
-        view::{
-            cosmic_applet_divider, cosmic_body_text_row, errors_row_widget, news_available_widget,
-            updates_available_widget, AppIcon, DisplayPackage, MAX_NEWS_LINES, MAX_UPDATE_LINES,
-        },
-        NewsState,
-    },
-    fl,
+use crate::app::view::{
+    cosmic_applet_divider, cosmic_body_text_row, errors_row_widget, news_available_widget,
+    updates_available_widget, AppIcon, DisplayPackage, MAX_NEWS_LINES, MAX_UPDATE_LINES,
 };
+use crate::app::{Message, NewsState, UpdatesState};
+use crate::{fl, CosmicAppletArch};
 use chrono::{DateTime, Local};
 use cosmic::{theme, Element};
 

--- a/cosmic-applet-arch/src/app/view/widgets.rs
+++ b/cosmic-applet-arch/src/app/view/widgets.rs
@@ -1,15 +1,12 @@
 use super::AppIcon;
-use crate::{app::Message, fl, news::DatedNewsItem};
+use crate::app::Message;
+use crate::fl;
+use crate::news::DatedNewsItem;
 use arch_updates_rs::{AurUpdate, DevelUpdate, PacmanUpdate, SourceRepo};
-use cosmic::{
-    iced::{
-        alignment::{Horizontal, Vertical},
-        Length,
-    },
-    theme,
-    widget::{JustifyContent, Widget},
-    Element,
-};
+use cosmic::iced::alignment::{Horizontal, Vertical};
+use cosmic::iced::Length;
+use cosmic::widget::{JustifyContent, Widget};
+use cosmic::{theme, Element};
 use std::fmt::Display;
 
 #[derive(Default)]

--- a/cosmic-applet-arch/src/core/localization.rs
+++ b/cosmic-applet-arch/src/core/localization.rs
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::sync::LazyLock;
-
-use i18n_embed::{
-    fluent::{fluent_language_loader, FluentLanguageLoader},
-    LanguageLoader,
-};
+use i18n_embed::fluent::{fluent_language_loader, FluentLanguageLoader};
+use i18n_embed::LanguageLoader;
 use rust_embed::RustEmbed;
+use std::sync::LazyLock;
 
 #[derive(RustEmbed)]
 #[folder = "i18n/"]

--- a/cosmic-applet-arch/src/core/mod.rs
+++ b/cosmic-applet-arch/src/core/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use directories::ProjectDirs;
-
 pub mod localization;
 
 pub fn proj_dirs() -> Option<ProjectDirs> {

--- a/cosmic-applet-arch/src/core/mod.rs
+++ b/cosmic-applet-arch/src/core/mod.rs
@@ -1,3 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use directories::ProjectDirs;
+
 pub mod localization;
+
+pub fn proj_dirs() -> Option<ProjectDirs> {
+    ProjectDirs::from("com", "nick42d", "cosmic-applet-arch")
+}

--- a/cosmic-applet-arch/src/core/mod.rs
+++ b/cosmic-applet-arch/src/core/mod.rs
@@ -3,6 +3,7 @@
 use directories::ProjectDirs;
 pub mod localization;
 
+/// ProjectDirs with the correct values for this application
 pub fn proj_dirs() -> Option<ProjectDirs> {
     ProjectDirs::from("com", "nick42d", "cosmic-applet-arch")
 }

--- a/cosmic-applet-arch/src/news.rs
+++ b/cosmic-applet-arch/src/news.rs
@@ -2,9 +2,8 @@
 use anyhow::Result;
 use chrono::FixedOffset;
 use latest_update::Arch;
-use news_impl::{get_latest_arch_news, Network};
-
 pub use news_impl::DatedNewsItem;
+use news_impl::{get_latest_arch_news, Network};
 
 mod latest_update;
 mod news_impl;

--- a/cosmic-applet-arch/src/news.rs
+++ b/cosmic-applet-arch/src/news.rs
@@ -10,6 +10,7 @@ mod latest_update;
 mod news_impl;
 
 #[derive(Clone)]
+#[cfg_attr(feature = "mock-api", allow(dead_code))]
 pub struct NewsCache(Vec<DatedNewsItem>);
 
 pub async fn get_news_online(
@@ -21,6 +22,7 @@ pub async fn get_news_online(
         .map(|updates| (updates.clone(), NewsCache(updates)))
 }
 
+#[cfg_attr(feature = "mock-api", allow(dead_code))]
 pub async fn get_news_offline(
     cache: &NewsCache,
 ) -> WarnedResult<Vec<DatedNewsItem>, String, anyhow::Error> {

--- a/cosmic-applet-arch/src/news/latest_update.rs
+++ b/cosmic-applet-arch/src/news/latest_update.rs
@@ -4,6 +4,8 @@ use directories::ProjectDirs;
 use std::path::PathBuf;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
+use crate::core::proj_dirs;
+
 use super::WarnedResult;
 
 const PACMAN_LOG_PATH: &str = "/var/log/pacman.log";
@@ -57,9 +59,8 @@ fn to_box_writer<T: AsyncWrite + Unpin + Send + 'static>(
 }
 
 fn platform_local_last_read_path() -> std::io::Result<PathBuf> {
-    let proj_dirs = ProjectDirs::from("com", "nick42d", "cosmic-applet-arch")
-        .ok_or(std::io::ErrorKind::Other)?;
-    Ok(proj_dirs
+    Ok(proj_dirs()
+        .ok_or(std::io::ErrorKind::Other)?
         .data_local_dir()
         .to_path_buf()
         .join(LOCAL_LAST_READ_PATH))

--- a/cosmic-applet-arch/src/news/latest_update.rs
+++ b/cosmic-applet-arch/src/news/latest_update.rs
@@ -126,7 +126,7 @@ async fn get_latest_pacman_update(
     let Some(last_update_line) = log
         .lines()
         .filter(|line| line.contains("starting full system upgrade"))
-        .last()
+        .next_back()
     else {
         return Ok(None);
     };

--- a/cosmic-applet-arch/src/news/latest_update.rs
+++ b/cosmic-applet-arch/src/news/latest_update.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Context};
 use chrono::{DateTime, FixedOffset};
-use directories::ProjectDirs;
 use std::path::PathBuf;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 

--- a/cosmic-applet-arch/src/news/latest_update.rs
+++ b/cosmic-applet-arch/src/news/latest_update.rs
@@ -1,11 +1,9 @@
+use super::WarnedResult;
+use crate::core::proj_dirs;
 use anyhow::{anyhow, Context};
 use chrono::{DateTime, FixedOffset};
 use std::path::PathBuf;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-
-use crate::core::proj_dirs;
-
-use super::WarnedResult;
 
 const PACMAN_LOG_PATH: &str = "/var/log/pacman.log";
 const LOCAL_LAST_READ_PATH: &str = "last_read";

--- a/cosmic-applet-arch/src/news/latest_update.rs
+++ b/cosmic-applet-arch/src/news/latest_update.rs
@@ -57,7 +57,10 @@ fn to_box_writer<T: AsyncWrite + Unpin + Send + 'static>(
 
 fn platform_local_last_read_path() -> std::io::Result<PathBuf> {
     Ok(proj_dirs()
-        .ok_or(std::io::ErrorKind::Other)?
+        .ok_or(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Unable to obtain a local data storage directory",
+        ))?
         .data_local_dir()
         .to_path_buf()
         .join(LOCAL_LAST_READ_PATH))


### PR DESCRIPTION
It was discovered that:
1. with multiple screens of panels cosmic runs an instance of the applet binary for each
2. checkupdates in sync mode can't run in parralel

So added a semaphore to ensure checkupdates in sync mode is not run in parrallel.

Good fix for 2 but not the ideal fix for 1 - we could potentially reduce CPU utilisation further by utilising client-server.